### PR TITLE
Add FormActionDomain to CSP for KDE akonadi tomboy resource

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -14,4 +14,11 @@
 );
 
 \OCP\Util::addscript('grauphel', 'loader');
+
+if (\method_exists(\OC::$server, 'getContentSecurityPolicyManager')) {
+    $policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+    $policy->addAllowedFormActionDomain('http://127.0.0.1:1965/'); //accept KDE akonadi tomboy resource
+    \OC::$server->getContentSecurityPolicyManager()->addDefaultPolicy($policy);
+}
+
 ?>


### PR DESCRIPTION
Hello,
I was getting  Content Security Policy error below:
`Refused to send form data to 'http://127.0.0.1:1965/' because it violates the following Content Security Policy directive: "form-action 'self'".`

So had to add FormAction doman to the policy in order to complete token workflow
