### PR TITLE
Fix exception showing up in NC19 log

### DIFF
--- a/controller/notescontroller.php
+++ b/controller/notescontroller.php
@@ -238,7 +238,7 @@ class NotesController extends Controller
     protected function getNotes()
     {
         $username = $this->user->getUid();
-        $notes  = new \OCA\Grauphel\Lib\NoteStorage($this->urlGen);
+        $notes  = new \OCA\Grauphel\Lib\NoteStorage($this->deps->urlGen);
         $notes->setUsername($username);
         return $notes;
     }


### PR DESCRIPTION
Based on the other controllers, it appears this was always broken.

Found the following exception in my Nextcloud log while trying to work out why Tomdroid doesn't sync (it shows success but no notes are created or updated on the server; Tomboy (1.15.9 on Windows) works fine now).

```
{
    "reqId": "RZpMJoQbsfMPUTu7YaTl",
    "level": 3,
    "time": "2021-01-18T07:16:28+01:00",
    "remoteAddr": "***REDACTED***",
    "user": "root",
    "app": "PHP",
    "method": "GET",
    "url": "/index.php/apps/grauphel/note/a5b2df86-6825-47a9-81a8-6ad85cd8b81d.html",
    "message": {
        "Exception": "Error",
        "Message": "Undefined property: OCA\\Grauphel\\Controller\\NotesController::$urlGen at /var/www/nextcloud19/apps/grauphel/controller/notescontroller.php#241",
        "Code": 0,
        "Trace": [
            {
                "file": "/var/www/nextcloud19/apps/grauphel/controller/notescontroller.php",
                "line": 241,
                "function": "onError",
                "class": "OC\\Log\\ErrorHandler",
                "type": "::",
                "args": [
                    8,
                    "Undefined property: OCA\\Grauphel\\Controller\\NotesController::$urlGen",
                    "/var/www/nextcloud19/apps/grauphel/controller/notescontroller.php",
                    241,
                    {
                        "username": "root"
                    }
                ]
            },
            {
                "file": "/var/www/nextcloud19/apps/grauphel/controller/notescontroller.php",
                "line": 58,
                "function": "getNotes",
                "class": "OCA\\Grauphel\\Controller\\NotesController",
                "type": "->",
                "args": []
            },
            {
                "file": "/var/www/nextcloud19/lib/private/AppFramework/Http/Dispatcher.php",
                "line": 170,
                "function": "html",
                "class": "OCA\\Grauphel\\Controller\\NotesController",
                "type": "->",
                "args": [
                    "a5b2df86-6825-47a9-81a8-6ad85cd8b81d"
                ]
            },
            {
                "file": "/var/www/nextcloud19/lib/private/AppFramework/Http/Dispatcher.php",
                "line": 100,
                "function": "executeController",
                "class": "OC\\AppFramework\\Http\\Dispatcher",
                "type": "->",
                "args": [
                    {
                        "user": {
                            "__class__": "OC\\User\\User"
                        },
                        "__class__": "OCA\\Grauphel\\Controller\\NotesController"
                    },
                    "html"
                ]
            },
            {
                "file": "/var/www/nextcloud19/lib/private/AppFramework/App.php",
                "line": 137,
                "function": "dispatch",
                "class": "OC\\AppFramework\\Http\\Dispatcher",
                "type": "->",
                "args": [
                    {
                        "user": {
                            "__class__": "OC\\User\\User"
                        },
                        "__class__": "OCA\\Grauphel\\Controller\\NotesController"
                    },
                    "html"
                ]
            },
            {
                "file": "/var/www/nextcloud19/lib/private/AppFramework/Routing/RouteActionHandler.php",
                "line": 47,
                "function": "main",
                "class": "OC\\AppFramework\\App",
                "type": "::",
                "args": [
                    "NotesController",
                    "html",
                    {
                        "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
                    },
                    {
                        "guid": "a5b2df86-6825-47a9-81a8-6ad85cd8b81d",
                        "_route": "grauphel.notes.html"
                    }
                ]
            },
            {
                "function": "__invoke",
                "class": "OC\\AppFramework\\Routing\\RouteActionHandler",
                "type": "->",
                "args": [
                    {
                        "guid": "a5b2df86-6825-47a9-81a8-6ad85cd8b81d",
                        "_route": "grauphel.notes.html"
                    }
                ]
            },
            {
                "file": "/var/www/nextcloud19/lib/private/Route/Router.php",
                "line": 297,
                "function": "call_user_func",
                "args": [
                    {
                        "__class__": "OC\\AppFramework\\Routing\\RouteActionHandler"
                    },
                    {
                        "guid": "a5b2df86-6825-47a9-81a8-6ad85cd8b81d",
                        "_route": "grauphel.notes.html"
                    }
                ]
            },
            {
                "file": "/var/www/nextcloud19/lib/base.php",
                "line": 1010,
                "function": "match",
                "class": "OC\\Route\\Router",
                "type": "->",
                "args": [
                    "/apps/grauphel/note/a5b2df86-6825-47a9-81a8-6ad85cd8b81d.html"
                ]
            },
            {
                "file": "/var/www/nextcloud19/index.php",
                "line": 37,
                "function": "handleRequest",
                "class": "OC",
                "type": "::",
                "args": []
            }
        ],
        "File": "/var/www/nextcloud19/lib/private/Log/ErrorHandler.php",
        "Line": 91,
        "CustomMessage": "--"
    },
    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0",
    "version": "19.0.7.1"
}
```
