### PR TITLE
Migration: correct Doctrine types for new table creation

### DIFF
--- a/lib/Migration/Version010002Date20220103070900.php
+++ b/lib/Migration/Version010002Date20220103070900.php
@@ -16,7 +16,7 @@ class Version010002Date20220103070900 extends SimpleMigrationStep
 		if (!$schema->hasTable('grauphel_oauth_tokens')) 
 		{
 			$table = $schema->createTable('grauphel_oauth_tokens');
-			$table->addColumn('token_id', 'integer', [ 'autoincrement' => true, 'notnull' => true, 'length' => 20, 'default' => 0 ]);
+			$table->addColumn('token_id', 'integer', [ 'autoincrement' => true, 'notnull' => true, 'length' => 20 ]);
 			$table->addColumn('token_user', 'text', [ 'length' => 64, 'notnull' => false ]);
 			$table->addColumn('token_type', 'text', [ 'length' => 16, 'notnull' => true ]);
 			$table->addColumn('token_key', 'text', [ 'length' => 128, 'notnull' => true ]);
@@ -31,7 +31,7 @@ class Version010002Date20220103070900 extends SimpleMigrationStep
 		if (!$schema->hasTable('grauphel_notes'))
 		{
 			$table = $schema->createTable('grauphel_notes');
-			$table->addColumn('note_id', 'integer', [ 'autoincrement' => true, 'notnull' => true, 'length' => 20, 'default' => 0 ]);
+			$table->addColumn('note_id', 'integer', [ 'autoincrement' => true, 'notnull' => true, 'length' => 20 ]);
 			$table->addColumn('note_user', 'text', [ 'length' => 64, 'notnull' => false ]);
 			$table->addColumn('note_guid', 'text', [ 'length' => 128, 'notnull' => true ]);
 			$table->addColumn('note_last_sync_revision', 'integer', [ 'notnull' => true, 'length' => 20, 'default' => 0 ]);
@@ -39,7 +39,7 @@ class Version010002Date20220103070900 extends SimpleMigrationStep
 			$table->addColumn('note_last_change_date', 'text', [ 'length' => 33, 'notnull' => true ]);
 			$table->addColumn('note_last_metadata_change_date', 'text', [ 'length' => 33, 'notnull' => true ]);
 			$table->addColumn('note_title', 'text', [ 'length' => 1024, 'notnull' => true ]);
-			$table->addColumn('note_content', 'clob', [ 'notnull' => true ]);
+			$table->addColumn('note_content', 'text', [ 'notnull' => true ]);
 			$table->addColumn('note_content_version', 'text', [ 'length' => 16, 'notnull' => true ]);
 			$table->addColumn('note_open_on_startup', 'integer', [ 'length' => 1, 'notnull' => true, 'default' => 0 ]);
 			$table->addColumn('note_pinned', 'integer', [ 'length' => 1, 'notnull' => true, 'default' => 0 ]);
@@ -50,7 +50,7 @@ class Version010002Date20220103070900 extends SimpleMigrationStep
 		if (!$schema->hasTable('grauphel_syncdata'))
 		{
 			$table = $schema->createTable('grauphel_syncdata');
-			$table->addColumn('syncdata_id', 'integer', [ 'autoincrement' => true, 'notnull' => true, 'length' => 20, 'default' => 0 ]);
+			$table->addColumn('syncdata_id', 'integer', [ 'autoincrement' => true, 'notnull' => true, 'length' => 20 ]);
 			$table->addColumn('syncdata_user', 'text', [ 'length' => 64, 'notnull' => true ]);
 			$table->addColumn('syncdata_current_sync_guid', 'text', [ 'length' => 64, 'notnull' => true ]);
 			$table->addColumn('syncdata_latest_sync_revision', 'integer', [ 'length' => 20, 'notnull' => true, 'default' => 0 ]);


### PR DESCRIPTION
Use 'text' with no length limit to imply old 'clob' type from XML schema. Remove defaults for ID fields as this causes an error in MySQL. Seems to fix https://github.com/grosjo/nextcloud-grauphel/issues/94.