### PR TITLE
Add CSP: form-action http://localhost:* to OAuth flow

### DIFF
--- a/controller/oauthcontroller.php
+++ b/controller/oauthcontroller.php
@@ -15,6 +15,7 @@ namespace OCA\Grauphel\Controller;
 
 use \OCP\AppFramework\Controller;
 use \OCP\AppFramework\Http;
+use \OCP\AppFramework\Http\ContentSecurityPolicy;
 use \OCP\AppFramework\Http\RedirectResponse;
 use \OCP\AppFramework\Http\TemplateResponse;
 
@@ -139,6 +140,11 @@ class OauthController extends Controller
                 ),
             )
         );
+
+        $csp = new ContentSecurityPolicy();
+        $csp->addAllowedFormActionDomain('http://localhost:*');
+        $res->setContentSecurityPolicy($csp);
+
         return $res;
     }
 


### PR DESCRIPTION
Using Chromium to authorising Tomboy against Grauphel running on Nextcloud 23,
when I clicked Authorise in the OAuth flow, I ran into the browser error:

  Refused to send form data to 'https://nextcloud.myserver.com/' because it
  violates the following Content Security Policy directive: "form-action 'self'"

Checking the network log, this wasn't the form posting itself, but it was after
the server responded with the redirect to the callback URL, which was being
rejected by the CSP of the original form. As OAuth of a local app is always
going to be unencrypted HTTP on localhost, it makes sense to unconditionally
add http://localhost:* to this form-action, which made it work for me.